### PR TITLE
Enable arbitrary working directories

### DIFF
--- a/LatexTablet.net/Program.cs
+++ b/LatexTablet.net/Program.cs
@@ -46,7 +46,9 @@ namespace LatexTablet.net
         XPathDocument myXPathDocument = new XPathDocument(sr);
         XslTransform myXslTransform = new XslTransform();
         XmlTextWriter writer = new XmlTextWriter(sw);
-        myXslTransform.Load("./mmltex.xsl");
+        string mmltexpath = System.Reflection.Assembly.GetEntryAssembly().Location;
+        mmltexpath = mmltexpath.Replace("TeXTablet.exe", "mmltex.xsl");
+        myXslTransform.Load(mmltexpath);
         myXslTransform.Transform(myXPathDocument, null, writer);
         writer.Close();
         string latex = sw.ToString();


### PR DESCRIPTION
TeXTablet can now be called from arbitrary working directories. Useful, if Application is called by different software (LaTeX Editor, Tablet Hotkey Manager, etc.)